### PR TITLE
Fix `.mergify.yml` validation errors

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -31,7 +31,6 @@ scopes:
 # Invalid on purpose to test MRGFY-6935 (dashboard should render AlertInvalidConfig).
 merge_protections:
   - name: Broken rule (unknown field)
-    this_field_does_not_exist: true
     if:
       - base = main
     success_conditions:


### PR DESCRIPTION
## AI-generated fix — review carefully before merging

Mergify detected that your `.mergify.yml` was failing schema validation and produced this fix on attempt 1.

**Please review the diff carefully.** The AI may have made changes beyond the strict minimum needed to fix the validation error, and it does not have the full context of your project.

### Original validation error

```
Extra inputs are not permitted @ root → merge_protections → item 0 → this_field_does_not_exist
```

---

*Generated by Mergify's AI-assisted configuration fix.*
