### PR TITLE
Fix `.mergify.yml` validation errors

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -25,7 +25,7 @@ queue_rules:
     # Larger batches cost more CI but ship faster on average.
     batch_size: 3
     # Wait briefly to coalesce concurrent PRs into one batch.
-    batch_max_wait_time: 30        # ← BUG #1: int instead of duration string ("30 seconds")
+    batch_max_wait_time: "30 seconds"        # ← BUG #1: int instead of duration string ("30 seconds")
     merge_conditions: *required_ci
 
   # Hotfix queue — bypasses the standard merge gate.
@@ -34,8 +34,7 @@ queue_rules:
       - label = hotfix
       - check-success = build
     batch_size: 1
-    speculative_checks: 1
-    merge_conditons:                # ← BUG #2: typo, missing 'i' in "conditions"
+    merge_conditions:                # ← BUG #2: typo, missing 'i' in "conditions"
       - check-success = unit-tests
 
 # Pull request rules — automation that runs on every PR event.
@@ -78,4 +77,3 @@ merge_protections:
     if:
       - base = main
     success_conditions: *required_ci
-    success_treshold: 100           # ← BUG #3: typo "treshold" + extra key not allowed on this rule


### PR DESCRIPTION
## AI-generated fix — review carefully before merging

Mergify detected that your `.mergify.yml` was failing schema validation and produced this fix on attempt 1.

**Please review the diff carefully.** The AI may have made changes beyond the strict minimum needed to fix the validation error, and it does not have the full context of your project.

### Original validation error

```
* Extra inputs are not permitted @ root → queue_rules → item 1 → speculative_checks
* Extra inputs are not permitted @ root → queue_rules → item 1 → merge_conditons
* Extra inputs are not permitted @ root → merge_protections → item 0 → success_treshold
```

---

*Generated by Mergify's AI-assisted configuration fix.*
