### PR TITLE
Fix `.mergify.yml` validation errors

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -34,8 +34,7 @@ queue_rules:
       - label = hotfix
       - check-success = build
     batch_size: 1
-    speculative_checks: 1
-    merge_conditons:
+    merge_conditions:
       - check-success = unit-tests
 
 # Pull request rules — automation that runs on every PR event.
@@ -78,4 +77,3 @@ merge_protections:
     if:
       - base = main
     success_conditions: *required_ci
-    success_treshold: 100


### PR DESCRIPTION
## AI-generated fix — review carefully before merging

Mergify detected that your `.mergify.yml` was failing schema validation and produced this fix on attempt 2.

**Please review the diff carefully.** The AI may have made changes beyond the strict minimum needed to fix the validation error, and it does not have the full context of your project.

### Original validation error

```
* Extra inputs are not permitted @ root → queue_rules → item 1 → speculative_checks
* Extra inputs are not permitted @ root → queue_rules → item 1 → merge_conditons
* Extra inputs are not permitted @ root → merge_protections → item 0 → success_treshold
```

---

*Generated by Mergify's AI-assisted configuration fix.*
