### PR TITLE
Fix `.mergify.yml` validation errors

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -25,9 +25,6 @@ queue_rules:
       - label = critical
       - check-success = build
     # Older config style migrated from pre-merge_conditions era.
-    conditions:
-      - check-success = test
-      - check-success = security-scan
     merge_conditions:
       - check-success = test
       - check-success = security-scan
@@ -41,7 +38,7 @@ pull_request_rules:
     actions:
       queue:
         name: default
-        method: squash-merge
+        method: squash
 
   - name: notify on-call when CI breaks
     conditions:
@@ -58,4 +55,3 @@ merge_protections:
     if:
       - base = main
     success_conditions: *required_ci
-    schedule: "weekdays 9 to 18"


### PR DESCRIPTION
## AI-generated fix — review carefully before merging

Mergify detected that your `.mergify.yml` was failing schema validation and produced this fix on attempt 2.

**Please review the diff carefully.** The AI may have made changes beyond the strict minimum needed to fix the validation error, and it does not have the full context of your project.

### Original validation error

```
* Cannot have both `conditions` and `merge_conditions`, only use `merge_conditions (`conditions` is deprecated) @ root → queue_rules → item 1
* Extra inputs are not permitted @ root → merge_protections → item 0 → schedule → weekdays 9 to 18
```

---

*Generated by Mergify's AI-assisted configuration fix.*
